### PR TITLE
Downgrade ecl to 16.1.2 and pin exactly

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,6 +28,8 @@ source:
     - patches/osx_tests.patch  # [osx]
     # Build a fasl library for ecl
     - patches/maxima.system.patch
+    # Disable test that fails with ecl 16.1.2 in some setups
+    - patches/rtest8.patch
 
 build:
   number: 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,7 @@ source:
     - patches/maxima.system.patch
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
 
 requirements:
@@ -39,13 +39,13 @@ requirements:
     - libtool
     - texinfo
   host:
-    - ecl >=6.1.3-1
+    - ecl 16.1.2
     - readline
     - gmp
     - bdw-gc
   run:
     - readline
-    - ecl
+    - {{ pin_compatible('ecl', max_pin='x.x.x') }}
     - gmp
     - {{ pin_compatible('bdw-gc') }}
 

--- a/recipe/patches/rtest8.patch
+++ b/recipe/patches/rtest8.patch
@@ -1,0 +1,16 @@
+Remove tests that are broken in some setups, see https://sourceforge.net/p/maxima/bugs/2340/
+--- a/tests/rtest8.mac
++++ b/tests/rtest8.mac
+@@ -393,12 +393,6 @@
+ e5 : quad_qawf (foo (u), u, au, omega, sin, limit=32);
+ quad_qawf (foo (u), u, au, omega, sin, epsabs=1e-10, limit=32, maxp1=100, limlst=10);
+ 
+-e5 : ev (e5, foo(u)=exp(-u));
+-quad_qawf (exp (- u), u, au, omega, sin, epsabs=1e-10, limit=32, maxp1=100, limlst=10);
+-
+-ev (e5, au=0, omega=2);
+-[.4000000000000001, 2.216570948815925E-11, 175, 0];
+-
+ e6 : quad_qawo (foo (u), u, au, bu, omega, cos, limit=64);
+ quad_qawo (foo (u), u, au, bu, omega, cos, epsrel=1e-8, epsabs=0.0, limit=64, maxp1=100);
+ 


### PR DESCRIPTION
Sage 8.3 runs into trouble with ecl 16.1.3 and to require maxima from within Sage, we need to build and run maxima with the same version it seems.

Fixes #9; see also https://github.com/conda-forge/sagelib-feedstock/issues/19.